### PR TITLE
refactored code to also read probes and forces with foam-extend

### DIFF
--- a/fluidfoam/readpostpro.py
+++ b/fluidfoam/readpostpro.py
@@ -7,6 +7,7 @@ This module provides functions to list and read OpenFoam PostProcessing Files:
 """
 import os
 import numpy as np
+from glob import glob
 
 
 def _find_latesttime(path):
@@ -43,12 +44,12 @@ def readforce(path, namepatch="forces", time_name="0", name="forces"):
 
     """
 
-    path_namepatch = os.path.join(path, "postProcessing", namepatch)
+    path_namepatch = glob(f'{path}/**/probes', recursive=True)[0]
     if time_name is "latestTime":
         time_name = _find_latesttime(path_namepatch)
     elif time_name is "mergeTime":
         time_list = []
-        dir_list = os.listdir(path + "/postProcessing/" + namepatch)
+        dir_list = os.listdir(path_namepatch)
         for directory in dir_list:
             try:
                 float(directory)
@@ -114,12 +115,12 @@ def readprobes(path, probes_name="probes", time_name="0", name="U"):
 
     """
 
-    path_probes_name = os.path.join(path, "postProcessing", probes_name)
+    path_probes_name = glob(f'{path}/**/probes', recursive=True)[0]
     if time_name is "latestTime":
         time_name = _find_latesttime(path_probes_name)
     elif time_name is "mergeTime":
         time_list = []
-        dir_list = os.listdir(path + "/postProcessing/" + probes_name)
+        dir_list = os.listdir(path_probes_name)
         for directory in dir_list:
             try:
                 float(directory)


### PR DESCRIPTION
foam-extend does not have a folder "postProcessing". In order to avoid this issue, I am searching for the probes or forces folder instead of hard coding a path including "postProcessing". 