### PR TITLE
fix: replace typo 'xz' by 'yz'

### DIFF
--- a/fluidfoam/meshvisu.py
+++ b/fluidfoam/meshvisu.py
@@ -220,7 +220,7 @@ class MeshVisu(object):
                 x0, z0 = self.__pointfile.values_x[i],  self.__pointfile.values_z[i]
                 x1, z1 = self.__pointfile.values_x[j],  self.__pointfile.values_z[j]
                 self.__edgesInBox.append(((x0, z0), (x1, z1)))
-        elif plane == 'xz':
+        elif plane == 'yz':
             for (i, j) in tmp_id_edges:
                 y0, z0 = self.__pointfile.values_y[i],  self.__pointfile.values_z[i]
                 y1, z1 = self.__pointfile.values_y[j],  self.__pointfile.values_z[j]


### PR DESCRIPTION
This pull request fixes a bug, introduced by a typo, which prevented the detection of the 'yz' plane in the method `MeshVisu._set_edges_in_box`.