### PR TITLE
minor error in read_probes from readpostpro

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ You can get the source code from `github
 
 The development mode is often useful. From the root directory, run::
 
-  python setup.py develop --user
+  python3 -m pip install --editable . --user
+  
+Or if you are using a virtual environment, run::
 
+  python3 -m pip install --editable .
 
 Committing instructions (in development mode)
 ---------------------------------------------

--- a/fluidfoam/readpostpro.py
+++ b/fluidfoam/readpostpro.py
@@ -175,7 +175,7 @@ def readprobes(path, probes_name="probes", time_name="0", name="U"):
             j += 1
         elif "#".encode() not in line:
             break
-    n_probes = j-2
+    n_probes = j-1
     probes_loc = np.zeros([n_probes, 3], dtype=float)
     j = 0
     header = True


### PR DESCRIPTION
The read_probes function was not counting the probes properly and not returning the coordinates of the last probe. In an OpenFOAM postprocessing file, the probes coordinates are written in the header after comments #. One line for each probe. One commented line was not counted. 